### PR TITLE
Fixed emitters and brightness scaling

### DIFF
--- a/Emissive.java
+++ b/Emissive.java
@@ -2,8 +2,7 @@
 //the member functions from Material.java
 
 public class Emissive extends Material{
-  Emissive(ColorDbl c, double b){
-    super(c,b);
+  Emissive(ColorDbl c){
+    super(c);
   }
-  //No Emissive-specific member functions have been added
 }

--- a/Glossy.java
+++ b/Glossy.java
@@ -3,9 +3,9 @@
 
 public class Glossy extends Material {
   double roughness, diffuseFac;
-  Glossy(ColorDbl col, double coeff, double diffuse){
+  Glossy(ColorDbl col, double rough, double diffuse){
     super(col);
-    roughness = coeff;
+    roughness = rough;
     diffuseFac = diffuse;
   }
   //getRoughness() is specific for Glossy material

--- a/JFX.java
+++ b/JFX.java
@@ -137,7 +137,7 @@ public class JFX extends Application {
     Label brightnessLabel = new Label("Brightness");
     grid.add(brightnessLabel, 0, 4);
     grid.setHalignment(brightnessLabel, HPos.RIGHT);
-    Slider brightnessSlider = new Slider(1,10,5);
+    Slider brightnessSlider = new Slider(1,10,3);
     brightnessSlider.setMajorTickUnit(1);
     brightnessSlider.setShowTickLabels(true);
     brightnessSlider.valueProperty().addListener((obs, oldval, newVal) ->

--- a/Material.java
+++ b/Material.java
@@ -8,7 +8,6 @@ import java.lang.Math;
 
 class Material{
   ColorDbl color;
-  double Brightness;
   Image texture;
   int width;
   int height;
@@ -17,34 +16,29 @@ class Material{
   //Default constructor, black diffuse material
   Material(){
     color = new ColorDbl();
-    Brightness = 1.0;
   }
   //Construct from color
   Material(ColorDbl C){
     color = new ColorDbl(C);
-    Brightness = 1.0;
   }
   //Construct with texture
   Material(Image t){
-    Brightness = 1.0;
     texture = t;
     pixelreader = texture.getPixelReader();
     width = (int)texture.getWidth();
     height = (int)texture.getHeight();
   }
-  //Construct with brightness, useful for emitters
-  Material(ColorDbl C, double b){
-    color = new ColorDbl(C);
-    Brightness = b;
-  }
   //Copy constructor
   Material(Material m){
     color = m.color;
-    Brightness = m.Brightness;
     texture = m.texture;
     width = m.width;
     height = m.height;
     pixelreader = m.pixelreader;
+  }
+  //Calculate brightness
+  double getBrightness(){
+    return Math.sqrt(color.R*color.R + color.G*color.G + color.B*color.B);
   }
   //Roughness can only be used with glossy material (overridden in Glossy.java)
   double getRoughness(){
@@ -61,6 +55,7 @@ class Material{
   ColorDbl getColor(){
     return new ColorDbl(color);
   }
+  //Overridden in Glossy.java
   double getDiffuseFac(){
     //Dummy return
     return -1.0;

--- a/Scene.java
+++ b/Scene.java
@@ -39,7 +39,7 @@ public class Scene{
     Material cyan = new Material(new ColorDbl(0.3,0.85,0.85));
     Material magenta = new Material(new ColorDbl(0.85,0.3,0.85));
     //Emmissive materials
-    Material EMISSION = new Emissive(new ColorDbl(1.0,1.0,1.0), brightness);
+    Material EMISSION = new Emissive(new ColorDbl(brightness, brightness, brightness));
     //Reflective materials
     Material Reflective = new Reflective(new ColorDbl(0.99,0.99,0.99));
     Material Mirror = new Reflective(new ColorDbl(0.95,0.99,0.95));
@@ -65,7 +65,7 @@ public class Scene{
     Vector3d FloorRightFar = new Vector3d(depth,-width/2.0,-height/2.0);
 
     //Vertex points ceiling light
-    double lampSize = 1.0;
+    double lampSize = 2.0;
     Vector3d CLNR = new Vector3d(depth/2.0 - lampSize, -lampSize, height/2.0);
     Vector3d CLFR = new Vector3d(depth/2.0 + lampSize, -lampSize, height/2.0);
     Vector3d CLFL = new Vector3d(depth/2.0 + lampSize,  lampSize, height/2.0);
@@ -91,7 +91,7 @@ public class Scene{
     // Additional items
     addBox(new Vector3d(11, -2.15, -3), 4, 4, 3, yellow);
     addObject(new Sphere(new Vector3d(6.5, -1.1, -4), 1.0, Reflective));
-    addObject(new Sphere(new Vector3d(7.5, 1.1, -4), 1.0, GlossyBlue));
+    addObject(new Sphere(new Vector3d(7.5, 1.1, -4), 1.0, GlossyYellow));
     addObject(new Sphere(new Vector3d(6.1, -3, -4.5), 0.5, white));
     addObject(new Sphere(new Vector3d(8.0, -4.1, -4.5), 0.5, Reflective));
     addObject(new Sphere(new Vector3d(6.7, 3.6, -4.5), 0.5, GlossyRed));

--- a/ToDo.txt
+++ b/ToDo.txt
@@ -3,3 +3,5 @@
   - Add function: Material.getuv()
 - Alternative glossy BRDF:
   - Generate random_unit_vec() to offset normal instead of the reflected ray
+- Emitter brightness should be the NORM of the color components
+  - 10 * color is NOT the same as (10*color.r, 10*color.g, 10*color.b)


### PR DESCRIPTION
Emissive objects' brightness is now defined directly through their color and not specified as a separate variable.
Material member variable "brightness" replaced by a getBrightness() getter. The brightness is defined directly through the color and not specified separately.
The appropriate changes have been made in RenderTask.java and Scene.java to reflect the brightness changes (i.e. changing from brightness to getBrightness() ).